### PR TITLE
Set the environment variable `DOCKER_INTERFACE` under `di run`

### DIFF
--- a/docker_interface/docker_interface.py
+++ b/docker_interface/docker_interface.py
@@ -121,6 +121,7 @@ def build_docker_run_command(configuration):
             parts.append('--env=%s' % key)
         else:
             parts.append('--env=%s=%s' % (key, value))
+    parts.append('--env=DOCKER_INTERFACE=true')
 
     # Forward ports
     for publish in run.pop('publish', []):

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -66,6 +66,6 @@ and modify your :code:`di.yml` configuration to read:
    build:
      tag: my-ipython
 
-Running :code:`di build` from the command line will build your image, and :code:`di run ipython` will run the :code:`ipython` command inside the container. Unless otherwise specified, Docker Interface uses the image built in the :code:`build` step to start a new container when you use the :code:`run` command.
+Running :code:`di build` from the command line will build your image, and :code:`di run ipython` will run the :code:`ipython` command inside the container. Unless otherwise specified, Docker Interface uses the image built in the :code:`build` step to start a new container when you use the :code:`run` command. Note: the :code:`run` command also sets the environment variable :code:`DOCKER_INTERFACE=true` which allows you to dynamically detect when running under the control of :code:`di`.
 
 A comprehensive list of variables that can be set in the :code:`di.yml` configuration can be found in the :doc:`plugin_reference`.

--- a/examples/env/README.rst
+++ b/examples/env/README.rst
@@ -1,0 +1,1 @@
+This example demonstrates that a default environment variable is set whe using :code:`di run`.

--- a/examples/env/check_env_var.py
+++ b/examples/env/check_env_var.py
@@ -1,0 +1,19 @@
+# Copyright 2019Spotify AB
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+if 'DOCKER_INTERFACE' not in os.environ:
+    raise RuntimeError('DOCKER_INTERFACE variable not set')
+

--- a/examples/env/di.yml
+++ b/examples/env/di.yml
@@ -1,0 +1,2 @@
+run:
+  image: python:3

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open('README.md') as fp:
 
 setup(
     name="docker_interface",
-    version="0.3.0",
+    version="0.4.0",
     packages=find_packages(),
     install_requires=[
         'jsonschema>=2.6.0',

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -20,6 +20,7 @@ import docker_interface.cli
 @pytest.fixture(params=[
     ('cython', ['python', '-c', '"add_two_numbers(1, 2)"'], True),
     ('ports', ['python', 'bind_to_port.py'], False),
+    ('env', ['python', 'check_env_var.py'], False),
 ])
 def example_definition(request):
     return request.param


### PR DESCRIPTION
This allows users to determine if they are running under the control of `di` and can be useful if there is a need to switch runtime behaviour dynamically dependent on this.